### PR TITLE
Potential fix for code scanning alert no. 8: Multiplication result converted to larger type

### DIFF
--- a/src/tier1/utlmemory.cpp
+++ b/src/tier1/utlmemory.cpp
@@ -18,7 +18,7 @@ m_nAllocationCount( nInitAllocationCount ), m_nGrowSize( nGrowSize ), m_unSizeOf
 	if (m_nAllocationCount)
 	{
 		UTLMEMORY_TRACK_ALLOC();
-		m_pMemory = PvAlloc( m_nAllocationCount * m_unSizeOfElements );
+		m_pMemory = PvAlloc( static_cast<size_t>(m_nAllocationCount) * m_unSizeOfElements );
 	}
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/pwnlaboratory/GameNetworkingSockets/security/code-scanning/8](https://github.com/pwnlaboratory/GameNetworkingSockets/security/code-scanning/8)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to avoid overflow. This can be done by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done using the larger type, and the result will be correctly stored in a `size_t` variable.

The best way to fix this without changing existing functionality is to cast `m_nAllocationCount` to `size_t` before the multiplication. This change should be made on line 21 of the file `src/tier1/utlmemory.cpp`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
